### PR TITLE
Disable line break on enter key in message input

### DIFF
--- a/client/js/chat.js
+++ b/client/js/chat.js
@@ -397,13 +397,14 @@ window.onload = async () => {
     message_input.addEventListener(`keydown`, async (evt) => {
         if (prompt_lock) return;
         if (evt.keyCode === 13 && !evt.shiftKey) {
+            evt.preventDefault();
             console.log('pressed enter');
             await handle_ask();
         } else {
             message_input.style.removeProperty('height');
             message_input.style.height = (message_input.scrollHeight+4) + 'px';
         }
-    });
+    });    
     
     send_button.addEventListener(`click`, async () => {
         console.log('clicked send');


### PR DESCRIPTION
small bug when pressing "enter" key to submit input.

Before
![before](https://user-images.githubusercontent.com/55147029/234662687-85338907-4292-4db2-9347-21bb1d020a4d.gif)

Fixed
![after](https://user-images.githubusercontent.com/55147029/234662713-7be878bf-c3e5-4d4c-97c0-34b6d3f4a221.gif)
