### PR TITLE
Fix port-forward & Add Multistage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM python:3.8-slim-buster
+# Build stage
+FROM python:3.8-alpine AS build
 
 WORKDIR /app
 
 COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+RUN apk add --no-cache build-base && \
+    pip3 install --user --no-cache-dir -r requirements.txt
 
 COPY . .
+
+# Production stage
+FROM python:3.8-alpine AS production
+
+WORKDIR /app
+
+COPY --from=build /root/.local /root/.local
+COPY . .
+
+ENV PATH=/root/.local/bin:$PATH
 
 CMD ["python3", "./run.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "1337:1337"
+      - "1338:1338"


### PR DESCRIPTION
There were two problems that i faced:
- First flask was up and running on the port 1338 (specified in config.json) but docker-compose was forwarding it on 1338:1338.
- Second I thought it would be nice to have a multistage Dockerfile, which is better because in the future pull requests we could add gunicorn to make the project suitable for production envs.
