### PR TITLE
fix docker port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "1337:1337"
+      - "1338:1338"


### PR DESCRIPTION
Error: Unable to access http://127.0.0.1:1338.

Resolution: To access http://127.0.0.1:1338, we need to map the port 1338 of our host machine to the port 1337 of the container.