### PR TITLE
Correct text overflow handling

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -146,6 +146,8 @@ body {
     display: flex;
     flex-direction: column;
     gap: 16px;
+    flex: auto;
+    min-width: 0;
 }
 
 .conversations .title {
@@ -167,6 +169,8 @@ body {
     display: flex;
     align-items: center;
     gap: 10px;
+    flex: auto;
+    min-width: 0;
 }
 
 .conversations i {
@@ -177,6 +181,8 @@ body {
 .convo-title {
     color: var(--colour-3);
     font-size: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .message {
@@ -230,6 +236,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 18px;
+    min-width: 0;
 }
 
 .message .content p,


### PR DESCRIPTION
During communication, chatgpt sent a link that broke the layout. So I decided to fix the text overflow handling. At the same time, I fixed the case when the first message was too long and pushed the conversation delete button and it became impossible to click on it.

Before:
![Before](https://user-images.githubusercontent.com/70522988/235212411-2136a812-507c-49f4-8e73-caaaf1938a75.jpg)

After:
![After](https://user-images.githubusercontent.com/70522988/235212392-0d4283ff-e4af-4861-9b2a-3898cc0d1ce9.jpg)
