### PR TITLE
Fixed bottom black bar for large devices

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -54,7 +54,7 @@ body {
     padding: var(--section-gap);
     background: var(--colour-1);
     color: var(--colour-3);
-    height: 100vh;
+    min-height: 100vh;
 }
 
 .row {


### PR DESCRIPTION
<h2>Title</h2>
<p>Fix black bar issue for large devices</p>

![Screenshot_25](https://user-images.githubusercontent.com/89025631/235289051-4a170b54-85f6-4fc9-bb61-a89237859a53.png)

<h2>Description</h2>
<p>This pull request fixes the issue of a black bar appearing at the bottom of the screen for large devices. The problem was caused by incorrect calculation of screen height in the code.</p>
<h3>Changes Made</h3>
<p>To fix this issue, I changed the <code>height</code> property from <code>height: 100vh</code> to <code>min-height: 100vh</code> in the relevant section of the code. This ensures that the element will take up at least the full height of the viewport, regardless of the size of the device screen.</p>
<h3>Testing</h3>
<p>I have tested this fix on a variety of devices with different screen sizes, and the black bar no longer appears.</p>
<p>Please review this pull request and let me know if any changes are needed. Thank you for considering my contribution!</p>

![Screenshot_26](https://user-images.githubusercontent.com/89025631/235289102-56865326-2333-4705-9118-4e8ee1d2040a.png)
