### PR TITLE
fix scrollbars for desktop and mobile site

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -85,6 +85,10 @@ body {
 
 .conversation {
     width: 100%;
+    min-height: 50%;
+    height: 100vh;
+    overflow-y: scroll;
+    overflow-x: hidden;
     display: flex;
     flex-direction: column;
     gap: 15px;
@@ -92,16 +96,16 @@ body {
 
 .conversation #messages {
     width: 100%;
-    height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: auto;
     overflow-wrap: break-word;
+    overflow-y: inherit;
+    overflow-x: hidden;
     padding-bottom: 50px;
 }
 
 .conversation .user-input {
-    max-height: 200px;
+    max-height: 10vh;
 }
 
 .conversation .user-input input {
@@ -384,8 +388,9 @@ input:checked+label:after {
 }
 
 .buttons {
+    min-height: 10vh;
     display: flex;
-    align-items: center;
+    align-items: start;
     justify-content: left;
     width: 100%;
 }
@@ -403,6 +408,15 @@ input:checked+label:after {
     color: var(--colour-3);
 }
 
+.disable-scrollbars::-webkit-scrollbar {
+  background: transparent; /* Chrome/Safari/Webkit */
+  width: 0px;
+}
+    
+.disable-scrollbars {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;  /* IE 10+ */
+}
 
 select {
     -webkit-border-radius: 8px;
@@ -583,14 +597,16 @@ ul {
     }
 
     .buttons {
-        align-items: flex-start;
-        flex-wrap: wrap;
-        gap: 15px;
-    }
+    flex-wrap: wrap;
+    gap: 5px;
+    padding-bottom: 10vh;
+    margin-bottom: 10vh;
+}
 
     .field {
-        width: fit-content;
-    }
+    min-height: 5%;
+    width: fit-content;
+}
 
     .mobile-sidebar {
         display: flex !important;

--- a/client/html/index.html
+++ b/client/html/index.html
@@ -85,7 +85,7 @@
                     </div>
                 </div>
             </div>
-            <div class="conversation">
+            <div class="conversation disable-scrollbars">
                 <div class="stop_generating stop_generating-hidden">
                     <button id="cancelButton">
                         <span>Stop Generating</span>


### PR DESCRIPTION
Before, there was a problem, when after some chatting with GPT, the scrolling was broken and the page could not be pulled down, that was mentioned in  issue https://github.com/xtekky/chatgpt-clone/issues/82 . The problem was fixed by modifying CSS and adding a visibility-disabling CSS class to a HTML file. Also, fixed media queries to optimize mobile version.