### PR TITLE
Input Box Height Reverts to Original Size After Text Deletion

### DIFF
--- a/client/html/index.html
+++ b/client/html/index.html
@@ -96,7 +96,7 @@
                 </div>
                 <div class="user-input">
                     <div class="box input-box">
-                        <textarea id="message-input" placeholder="Ask a question" cols="30" rows="10" style="white-space: pre-wrap;"></textarea>
+                        <textarea id="message-input" placeholder="Ask a question" cols="30" rows="10" style="white-space: pre-wrap;" oninput="resizeTextarea(this)"></textarea>
                         <div id="send-button">
                             <i class="fa-regular fa-paper-plane-top"></i>
                         </div>

--- a/client/js/chat.js
+++ b/client/js/chat.js
@@ -14,6 +14,11 @@ let prompt_lock = false;
 
 hljs.addPlugin(new CopyButtonPlugin());
 
+function resizeTextarea(textarea) {
+  textarea.style.height = '80px';
+  textarea.style.height = Math.min(textarea.scrollHeight, 200) + 'px';
+}
+
 const format = (text) => {
   return text.replace(/(?:\r\n|\r|\n)/g, "<br>");
 };


### PR DESCRIPTION
When entering text in the input box, if the text is too large, the height of the input box expands. However, after deleting the text, the input box does not revert to its original smaller size. I have fixed this for all the devices.