### PR TITLE
Possible fix for Issues #79 and #103

### DIFF
--- a/server/backend.py
+++ b/server/backend.py
@@ -78,6 +78,17 @@ class Backend_Api:
                 stream  = True
             )
 
+            if gpt_resp.status_code >= 400:
+                error_data =gpt_resp.json().get('error', {})
+                error_code = error_data.get('code', None)
+                error_message = error_data.get('message', "An error occurred")
+                return {
+                    'successs': False,
+                    'error_code': error_code,
+                    'message': error_message,
+                    'status_code': gpt_resp.status_code
+                }, gpt_resp.status_code
+
             def stream():
                 for chunk in gpt_resp.iter_lines():
                     try:


### PR DESCRIPTION
I added this conditional statement:

```
if gpt_resp.status_code >= 400:
                error_data =gpt_resp.json().get('error', {})
                error_code = error_data.get('code', None)
                error_message = error_data.get('message', "An error occurred")
                return {
                    'successs': False,
                    'error_code': error_code,
                    'message': error_message,
                    'status_code': gpt_resp.status_code
                }, gpt_resp.status_code
```
                
The GUI displays the JSON, but it is descriptive enough.

![image](https://github.com/xtekky/chatgpt-clone/assets/77696721/649b1ea3-51f3-465c-999b-4cb3e7350a95)


This will help users troubleshoot when they are having API issues such as invalid API keys and expired free trials.


